### PR TITLE
Lint undefined parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -840,9 +840,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "version": "3.7.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+            "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
             "dev": true
         },
         "uri-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,12 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@types/js-levenshtein": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz",
+            "integrity": "sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==",
+            "dev": true
+        },
         "@types/mocha": {
             "version": "2.2.48",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -445,6 +451,11 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
+        },
+        "js-levenshtein": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
         },
         "js-tokens": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "vscode-kubernetes-tools-api": "^1.0.0"
     },
     "devDependencies": {
-        "typescript": "^2.6.1",
+        "typescript": "^3.7.3",
         "vscode": "^1.1.6",
         "tslint": "^5.8.0",
         "@types/node": "^7.0.43",

--- a/package.json
+++ b/package.json
@@ -101,15 +101,17 @@
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
+        "js-levenshtein": "^1.1.6",
         "querystring": "^0.2.0",
         "vscode-kubernetes-tools-api": "^1.0.0"
     },
     "devDependencies": {
-        "typescript": "^3.7.3",
-        "vscode": "^1.1.6",
-        "tslint": "^5.8.0",
+        "@types/js-levenshtein": "^1.1.0",
+        "@types/mocha": "^2.2.42",
         "@types/node": "^7.0.43",
-        "@types/mocha": "^2.2.42"
+        "tslint": "^5.8.0",
+        "typescript": "^3.7.3",
+        "vscode": "^1.1.6"
     },
     "extensionDependencies": [
         "ms-kubernetes-tools.vscode-kubernetes-tools",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "onCommand:gatekeeper.violations",
         "onCommand:gatekeeper.show",
         "onCommand:gatekeeper.showRego",
+        "onLanguage:rego",
         "onView:extension.vsKubernetesExplorer"
     ],
     "main": "./out/extension",

--- a/src/diagnostics/codeactionprovider.ts
+++ b/src/diagnostics/codeactionprovider.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode';
+
+import { linters } from './diagnostics';
+import { flatten } from '../utils/array';
+
+export namespace GatekeeperCodeActionProvider {
+    export function create(): vscode.CodeActionProvider {
+        return new CodeActionProvider();
+    }
+}
+
+class CodeActionProvider implements vscode.CodeActionProvider {
+    provideCodeActions(document: vscode.TextDocument, _range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, _token: vscode.CancellationToken): vscode.ProviderResult<(vscode.Command | vscode.CodeAction)[]> {
+        return provideCodeActions(document, context);
+    }
+}
+
+async function provideCodeActions(document: vscode.TextDocument, context: vscode.CodeActionContext): Promise<(vscode.Command | vscode.CodeAction)[]> {
+    // TODO: it would be really good if we could cache some of this info inside the Diagnostic, because
+    // it seems like we are repeating calculations...
+    if (!isLintable(document)) {
+        return [];
+    }
+
+    const actionsPromises = linters.map((l) => l.fixes(document, document.getText(), context.diagnostics));
+    const actions = await Promise.all(actionsPromises);
+    return flatten(...actions);
+}
+
+function isLintable(document: vscode.TextDocument): boolean {
+    return document.languageId === 'rego';
+}

--- a/src/diagnostics/diagnostics.ts
+++ b/src/diagnostics/diagnostics.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+
+import { Linter } from './linter';
+import { UNDEFINED_PARAMETERS_LINTER } from './undefined-parameters';
+
+export const linters: ReadonlyArray<Linter> = [
+    UNDEFINED_PARAMETERS_LINTER,
+];
+
+export function initialise() {
+    const diagnostics = vscode.languages.createDiagnosticCollection('Gatekeeper');
+    const lintDocument = lintTo(diagnostics);
+
+    vscode.workspace.onDidOpenTextDocument(lintDocument);
+    vscode.workspace.onDidChangeTextDocument((e) => lintDocument(e.document));  // TODO: we could use the change hint
+    vscode.workspace.onDidSaveTextDocument(lintDocument);
+    vscode.workspace.onDidCloseTextDocument((d) => diagnostics.delete(d.uri));
+    vscode.workspace.textDocuments.forEach(lintDocument);
+}
+
+function lintTo(reporter: vscode.DiagnosticCollection): (document: vscode.TextDocument) => Promise<void> {
+    return (document) => lintDocumentTo(document, reporter);
+}
+
+async function lintDocumentTo(document: vscode.TextDocument, reporter: vscode.DiagnosticCollection): Promise<void> {
+    // Is it a Rego document?
+    if (!isLintable(document)) {
+        return;
+    }
+    const linterPromises = linters.map((l) => l.lint(document, document.getText()));
+    const linterResults = await Promise.all(linterPromises);
+    const diagnostics = ([] as vscode.Diagnostic[]).concat(...linterResults);
+    reporter.set(document.uri, diagnostics);
+}
+
+function isLintable(document: vscode.TextDocument): boolean {
+    return document.languageId === 'rego';
+}

--- a/src/diagnostics/linter.ts
+++ b/src/diagnostics/linter.ts
@@ -1,0 +1,6 @@
+import { TextDocument, Diagnostic, CodeAction } from "vscode";
+
+export interface Linter {
+    lint(document: TextDocument, text: string): Promise<Diagnostic[]>;
+    fixes(document: TextDocument, text: string, diagnostics: Diagnostic[]): CodeAction[];
+}

--- a/src/diagnostics/linter.ts
+++ b/src/diagnostics/linter.ts
@@ -2,5 +2,5 @@ import { TextDocument, Diagnostic, CodeAction } from "vscode";
 
 export interface Linter {
     lint(document: TextDocument, text: string): Promise<Diagnostic[]>;
-    fixes(document: TextDocument, text: string, diagnostics: Diagnostic[]): CodeAction[];
+    fixes(document: TextDocument, text: string, diagnostics: ReadonlyArray<Diagnostic>): Promise<CodeAction[]>;
 }

--- a/src/diagnostics/undefined-parameters.ts
+++ b/src/diagnostics/undefined-parameters.ts
@@ -1,0 +1,88 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { Linter } from './linter';
+import * as regex from '../utils/regex';
+
+// The idea with this one is that if the .rego contains an expression of
+// the form `input.parameters.<identifier>` then the schema should contain
+// a property named <identifier>.
+//
+// For the time being we are going to postulate a relationship of the
+// form foo.rego <-> foo.schema.json
+
+class UndefinedParametersLinter implements Linter {
+    async lint(document: vscode.TextDocument, text: string): Promise<vscode.Diagnostic[]> {
+        const schema = await associatedSchema(document);
+        const diagnostics = lint(document, text, schema);
+        return Array.of(...diagnostics);
+    }
+
+    fixes(_document: vscode.TextDocument, _text: string, _diagnostics: vscode.Diagnostic[]): vscode.CodeAction[] {
+        return [];
+    }
+}
+
+const PARAMETER_REF_REGEX = /input\.parameters\.([a-z][a-z0-9_]*)/ig;
+
+function* lint(document: vscode.TextDocument, text: string, schema: JSONSchema | null): IterableIterator<vscode.Diagnostic> {
+    if (!schema || !schema.properties) {
+        return;
+    }
+
+    const parameterReferences = Array.of(...regex.exec(text, PARAMETER_REF_REGEX));
+    if (!parameterReferences) {
+        return;
+    }
+
+    for (const reference of parameterReferences) {
+        if (reference.groups.length < 2) {
+            continue;
+        }
+
+        const parameterName = reference.groups[1];
+        if (parameterName) {
+            if (!schema.properties[parameterName]) {
+                const referenceRange = textRange(document, reference.index, reference.groups[0].length);
+                const diagnostic = new vscode.Diagnostic(referenceRange, `Schema file does not define property '${parameterName}'`, vscode.DiagnosticSeverity.Warning);
+                diagnostic.code = DIAGNOSTIC_NO_DEFINITION;
+                yield diagnostic;
+            }
+        }
+    }
+}
+
+async function associatedSchema(document: vscode.TextDocument): Promise<JSONSchema | null> {
+    try {
+        const regoPath = document.uri.fsPath;
+        const schemaPath = changeExtension(regoPath, 'schema.json');
+        const schemaDocument = await vscode.workspace.openTextDocument(schemaPath);
+        const schemaText = schemaDocument.getText();
+        const schema = JSON.parse(schemaText);
+        return schema;
+    } catch {
+        // It throws if the schema document doesn't exist or isn't parseable - we can just abandon ship in these cases
+        return null;
+    }
+}
+
+interface JSONSchema {
+    readonly type?: string;
+    readonly properties?: { [name: string]: JSONSchema };
+    readonly items?: JSONSchema;
+}
+
+function changeExtension(filePath: string, newExt: string): string {
+    const ext = path.extname(filePath);
+    const basePath = filePath.substr(0, filePath.length - ext.length);
+    return `${basePath}.${newExt}`;
+}
+
+function textRange(document: vscode.TextDocument, index: number, length: number): vscode.Range {
+    const start = document.positionAt(index);
+    const end = document.positionAt(index + length);
+    return new vscode.Range(start, end);
+}
+
+const DIAGNOSTIC_NO_DEFINITION = 'gatekeeper_no_definition';
+
+export const UNDEFINED_PARAMETERS_LINTER = new UndefinedParametersLinter();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { showViolations } from './commands/showViolations';
 import { showResource } from './commands/showResource';
 import { showRego } from './commands/showRego';
 import { ConstraintTemplateRegoFileSystemProvider, GK_REGO_RESOURCE_SCHEME } from './ui/rego-only.vfs';
+import * as diagnostics from './diagnostics/diagnostics';
 
 export async function activate(context: vscode.ExtensionContext) {
     const clusterExplorer = await k8s.extension.clusterExplorer.v1;
@@ -33,6 +34,8 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(...disposables);
 
     clusterExplorer.api.registerNodeContributor(ResourceBrowser.create(kubectl.api, context));
+
+    diagnostics.initialise();
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { showResource } from './commands/showResource';
 import { showRego } from './commands/showRego';
 import { ConstraintTemplateRegoFileSystemProvider, GK_REGO_RESOURCE_SCHEME } from './ui/rego-only.vfs';
 import * as diagnostics from './diagnostics/diagnostics';
+import { GatekeeperCodeActionProvider } from './diagnostics/codeactionprovider';
 
 export async function activate(context: vscode.ExtensionContext) {
     const clusterExplorer = await k8s.extension.clusterExplorer.v1;
@@ -21,13 +22,17 @@ export async function activate(context: vscode.ExtensionContext) {
         return;
     }
 
+    const regoSelector = { language: 'rego', scheme: 'file' };
+
     const regofs = new ConstraintTemplateRegoFileSystemProvider(kubectl.api);
+    const codeActionProvider = GatekeeperCodeActionProvider.create();
 
     const disposables = [
         vscode.commands.registerCommand('gatekeeper.install', install),
         vscode.commands.registerCommand('gatekeeper.show', showResource),
         vscode.commands.registerCommand('gatekeeper.showRego', showRego),
         vscode.commands.registerCommand('gatekeeper.violations', showViolations),
+        vscode.languages.registerCodeActionsProvider(regoSelector, codeActionProvider, { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }),
         vscode.workspace.registerFileSystemProvider(GK_REGO_RESOURCE_SCHEME, regofs),
     ];
 

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,50 @@
+export function flatten<T>(...arrays: ReadonlyArray<T>[]): T[] {
+    return Array.of<T>().concat(...arrays);
+}
+
+export function definedOf<T>(...items: (T | undefined)[]): T[] {
+    return items.filter((i) => i !== undefined).map((i) => i!);
+}
+
+declare global {
+    interface Array<T> {
+        choose<U>(fn: (t: T) => U | undefined): U[];
+        distinct(): T[];
+        filterAsync(fn: (t: T) => Thenable<boolean>): Promise<T[]>;
+    }
+}
+function choose<T, U>(this: T[], fn: (t: T) => U | undefined): U[] {
+    return this.map(fn).filter((u) => u !== undefined).map((u) => u!);
+}
+
+function distinct<T>(this: T[]): T[] {
+    const values = new Set<T>(this).values();
+    return Array.of(...values);
+}
+
+async function filterAsync<T>(this: T[], fn: (t: T) => Thenable<boolean>): Promise<T[]> {
+    const filterablePromises = this.map((o) => ({ accept: fn(o), value: o }));
+    const filterables = await Promise.all(filterablePromises);
+    return filterables.filter((o) => o.accept).map((o) => o.value);
+}
+
+if (!Array.prototype.choose) {
+    Object.defineProperty(Array.prototype, 'choose', {
+        enumerable: false,
+        value: choose
+    });
+}
+
+if (!Array.prototype.distinct) {
+    Object.defineProperty(Array.prototype, 'distinct', {
+        enumerable: false,
+        value: distinct
+    });
+}
+
+if (!Array.prototype.filterAsync) {
+    Object.defineProperty(Array.prototype, 'filterAsync', {
+        enumerable: false,
+        value: filterAsync
+    });
+}

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,0 +1,14 @@
+export interface Match {
+    readonly index: number;
+    readonly groups: ReadonlyArray<string>;
+}
+
+export function* exec(text: string, regex: RegExp): IterableIterator<Match> {
+    while (true) {
+        const match = regex.exec(text);
+        if (!match) {
+            return;
+        }
+        yield { index: match.index, groups: match };
+    }
+}


### PR DESCRIPTION
Displays a wiggly if a .rego file contains an `input.parameters.<identifier>` where there is a corresponding schema file and `<identifier>` is not present in the schema.

A schema file is 'associated' if it has the same base name as the .rego file and the extension `.schema.json` e.g. foo.rego would have be associated with foo.schema.json.  This is a tentative developer experience which needs to be evaluated in a more holistic way...