### PR TITLE
Template synthesis

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "onCommand:gatekeeper.show",
         "onCommand:gatekeeper.showRego",
         "onCommand:gatekeeper.enforcementAction",
+        "onCommand:gatekeeper.deployTemplate",
         "onLanguage:rego",
         "onView:extension.vsKubernetesExplorer"
     ],
@@ -53,6 +54,10 @@
             {
                 "command": "gatekeeper.enforcementAction",
                 "title": "Enforcement Action"
+            },
+            {
+                "command": "gatekeeper.deployTemplate",
+                "title": "Deploy as Gatekeeper Constraint Template"
             }
         ],
         "menus": {
@@ -81,6 +86,13 @@
                     "command": "gatekeeper.enforcementAction",
                     "group": "5",
                     "when": "viewItem =~ /gatekeeper\\.constraint/i"
+                }
+            ],
+            "editor/context": [
+                {
+                    "command": "gatekeeper.deployTemplate",
+                    "group": "99@2",
+                    "when": "editorLangId == rego"
                 }
             ],
             "commandPalette": [

--- a/src/authoring/associations.ts
+++ b/src/authoring/associations.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export async function associatedSchema(document: vscode.TextDocument): Promise<JSONSchema | null> {
+    try {
+        const schemaDocument = await associatedSchemaDocument(document);
+        if (!schemaDocument) {
+            return null;
+        }
+        const schemaText = schemaDocument.getText();
+        const schema = JSON.parse(schemaText);
+        return schema;
+    } catch {
+        // It throws if the schema document doesn't exist or isn't parseable - we can just abandon ship in these cases
+        return null;
+    }
+}
+
+export async function associatedSchemaDocument(document: vscode.TextDocument): Promise<vscode.TextDocument | null> {
+    try {
+        const regoPath = document.uri.fsPath;
+        const schemaPath = changeExtension(regoPath, 'schema.json');
+        const schemaDocument = await vscode.workspace.openTextDocument(schemaPath);
+        return schemaDocument;
+    } catch {
+        // It throws if the schema document doesn't exist or isn't parseable - we can just abandon ship in these cases
+        return null;
+    }
+}
+
+export interface JSONSchema {
+    readonly type?: string;
+    readonly properties?: { [name: string]: JSONSchema };
+    readonly items?: JSONSchema;
+}
+
+function changeExtension(filePath: string, newExt: string): string {
+    const ext = path.extname(filePath);
+    const basePath = filePath.substr(0, filePath.length - ext.length);
+    return `${basePath}.${newExt}`;
+}

--- a/src/commands/deployTemplate.ts
+++ b/src/commands/deployTemplate.ts
@@ -1,0 +1,5 @@
+import * as vscode from 'vscode';
+
+export async function deployTemplate(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
+    await vscode.window.showInformationMessage('makin templates');
+}

--- a/src/commands/deployTemplate.ts
+++ b/src/commands/deployTemplate.ts
@@ -1,5 +1,69 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
 
-export async function deployTemplate(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
-    await vscode.window.showInformationMessage('makin templates');
+import { associatedSchema, JSONSchema } from '../authoring/associations';
+
+export async function deployTemplate(textEditor: vscode.TextEditor, _edit: vscode.TextEditorEdit) {
+    // what we need to do:
+    // - combine the .rego, magic comments and schema into one big honkin YAML
+    // - display it to the user
+    // - get their okay
+    // - BAG IT UP AND SHIP IT OUT
+
+    const regoDoc = textEditor.document;
+    const associatedSchemaObj = await associatedSchema(regoDoc);
+
+    if (!associatedSchemaObj) {
+        await vscode.window.showErrorMessage('No associated schema - extension does not yet support this case');
+        return;
+    }
+
+    const templateName = path.basename(regoDoc.uri.fsPath, '.rego');
+    const rego = regoDoc.getText();
+
+    const template = constraintTemplate(templateName, rego, associatedSchemaObj);
+
+    const templateYAML = yaml.safeDump(template);
+
+    console.log(templateYAML);
+}
+
+function constraintTemplate(templateName: string, rego: string, schema: JSONSchema): any {
+    return {
+        apiVersion: "templates.gatekeeper.sh/v1beta1",
+        kind: "ConstraintTemplate",
+        metadata: {
+            name: templateName
+        },
+        spec: {
+            crd: {
+                spec: constraintTemplateCRDSpec(templateName, schema)
+            },
+            targets: [
+                constraintTemplateTarget(rego)
+            ]
+        }
+    };
+}
+
+function constraintTemplateCRDSpec(templateName: string, schema: JSONSchema): any {
+    return {
+        names: {
+            kind: templateName + 'Kind',
+            listKind: templateName + 'KindList',
+            plural: templateName + 'Plural',
+            singular: templateName
+        },
+        validation: {
+            openAPIV3Schema: schema
+        }
+    };
+}
+
+function constraintTemplateTarget(rego: string): any {
+    return {
+        target: 'admission.k8s.gatekeeper.sh',
+        rego: rego
+    };
 }

--- a/src/commands/deployTemplate.ts
+++ b/src/commands/deployTemplate.ts
@@ -19,7 +19,7 @@ export async function deployTemplate(textEditor: vscode.TextEditor, _edit: vscod
         return;
     }
 
-    const templateName = path.basename(regoDoc.uri.fsPath, '.rego');
+    const templateName = path.basename(regoDoc.uri.fsPath, '.rego');  // TODO: or the package name?
     const rego = regoDoc.getText();
 
     const template = constraintTemplate(templateName, rego, associatedSchemaObj);
@@ -48,12 +48,14 @@ function constraintTemplate(templateName: string, rego: string, schema: JSONSche
 }
 
 function constraintTemplateCRDSpec(templateName: string, schema: JSONSchema): any {
+    const kind = kindify(templateName);
+    const identifier = identifierfy(templateName);
     return {
         names: {
-            kind: templateName + 'Kind',
-            listKind: templateName + 'KindList',
-            plural: templateName + 'Plural',
-            singular: templateName
+            kind: kind,
+            listKind: kind + 'List',
+            plural: identifier,
+            singular: identifier
         },
         validation: {
             openAPIV3Schema: schema
@@ -66,4 +68,26 @@ function constraintTemplateTarget(rego: string): any {
         target: 'admission.k8s.gatekeeper.sh',
         rego: rego
     };
+}
+
+function kindify(name: string): string {
+    if (!name || name.length === 0) {
+        return '';
+    }
+
+    const bits = name.split(/[^a-zA-Z0-9]/);
+    const titleCasedBits = bits.map((s) => titleCase(s));
+    const kindified = titleCasedBits.join('');
+    return kindified;
+}
+
+function titleCase(s: string): string {
+    if (s === '') {
+        return s;
+    }
+    return s[0].toUpperCase() + s.slice(1);
+}
+
+function identifierfy(name: string): string {
+    return name.replace(/^a-zA-Z0-9/g, '').toLowerCase();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { ConstraintTemplateRegoFileSystemProvider, GK_REGO_RESOURCE_SCHEME } fro
 import * as diagnostics from './diagnostics/diagnostics';
 import { GatekeeperCodeActionProvider } from './diagnostics/codeactionprovider';
 import { setEnforcementAction } from './commands/setEnforcementAction';
+import { deployTemplate } from './commands/deployTemplate';
 
 export async function activate(context: vscode.ExtensionContext) {
     const clusterExplorer = await k8s.extension.clusterExplorer.v1;
@@ -34,6 +35,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('gatekeeper.showRego', showRego),
         vscode.commands.registerCommand('gatekeeper.enforcementAction', setEnforcementAction),
         vscode.commands.registerCommand('gatekeeper.violations', showViolations),
+        vscode.commands.registerTextEditorCommand('gatekeeper.deployTemplate', deployTemplate),
         vscode.languages.registerCodeActionsProvider(regoSelector, codeActionProvider, { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }),
         vscode.workspace.registerFileSystemProvider(GK_REGO_RESOURCE_SCHEME, regofs),
     ];

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -1,0 +1,72 @@
+import * as vscode from 'vscode';
+
+const END_DIALOG_FN_NAME = "endDialog";
+export const END_DIALOG_FN = `${END_DIALOG_FN_NAME}()`;
+export function END_MESSAGE_DIALOG_WITH(s: string) { return `${END_DIALOG_FN_NAME}("${s}")`; }
+
+export function dialog(tabTitle: string, htmlBody: string, formId: string): Promise<{ [key: string]: string }> {
+    return new Promise<any>((resolve, _reject) => {
+        const postbackScript = `<script>
+        function ${END_DIALOG_FN} {
+            const vscode = acquireVsCodeApi();
+            const s = {};
+            for (const e of document.forms['${formId}'].elements) {
+                s[e.name] = e.value;
+            }
+            vscode.postMessage(s);
+        }
+        </script>`;
+
+        const html = postbackScript + htmlBody;
+        const w = vscode.window.createWebviewPanel('gkvs-dialog', tabTitle, vscode.ViewColumn.Active, {
+            retainContextWhenHidden: false,
+            enableScripts: true,
+        });
+        w.webview.html = html;
+        const cancelSubscription = w.onDidDispose(() => resolve(undefined));
+        w.webview.onDidReceiveMessage((m) => {
+            cancelSubscription.dispose();
+            w.dispose();
+            resolve(m);
+        });
+        w.reveal();
+    });
+}
+
+export interface MultiButtonDialogResult {
+    readonly selectedButton: string;
+    readonly formData: { [key: string]: string };
+}
+
+export function multiButtonDialog(tabTitle: string, htmlBody: string, formId: string): Promise<MultiButtonDialogResult> {
+    return new Promise<any>((resolve, _reject) => {
+        const postbackScript = `<script>
+        function ${END_DIALOG_FN_NAME}(btn) {
+            const vscode = acquireVsCodeApi();
+            const s = {};
+            for (const e of document.forms['${formId}'].elements) {
+                s[e.name] = e.value;
+            }
+            const r = {
+                selectedButton: btn,
+                formData: s
+            };
+            vscode.postMessage(r);
+        }
+        </script>`;
+
+        const html = postbackScript + htmlBody;
+        const w = vscode.window.createWebviewPanel('gkvs-dialog', tabTitle, vscode.ViewColumn.Active, {
+            retainContextWhenHidden: false,
+            enableScripts: true,
+        });
+        w.webview.html = html;
+        const cancelSubscription = w.onDidDispose(() => resolve(undefined));
+        w.webview.onDidReceiveMessage((m) => {
+            cancelSubscription.dispose();
+            w.dispose();
+            resolve(m);
+        });
+        w.reveal();
+    });
+}


### PR DESCRIPTION
Adds a command to deploy a .rego file to Kubernetes as a Gatekeeper constraint template.  The name and CRD names are inferred from the file name; the CRD schema is extracted from a sibling file with the same name and the extension `.schema.json`.  This is a tentative authoring convention - PRing this command is part of exploring that convention.