### PR TITLE
Show or create parameters schema from .rego file

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
             },
             {
                 "command": "gatekeeper.schema",
-                "title": "Parameters Schema"
+                "title": "Gatekeeper Parameters Schema"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "onCommand:gatekeeper.showRego",
         "onCommand:gatekeeper.enforcementAction",
         "onCommand:gatekeeper.deployTemplate",
+        "onCommand:gatekeeper.schema",
         "onLanguage:rego",
         "onView:extension.vsKubernetesExplorer"
     ],
@@ -58,6 +59,10 @@
             {
                 "command": "gatekeeper.deployTemplate",
                 "title": "Deploy as Gatekeeper Constraint Template"
+            },
+            {
+                "command": "gatekeeper.schema",
+                "title": "Parameters Schema"
             }
         ],
         "menus": {
@@ -92,6 +97,11 @@
                 {
                     "command": "gatekeeper.deployTemplate",
                     "group": "99@2",
+                    "when": "editorLangId == rego"
+                },
+                {
+                    "command": "gatekeeper.schema",
+                    "group": "99@3",
                     "when": "editorLangId == rego"
                 }
             ],

--- a/src/authoring/associations.ts
+++ b/src/authoring/associations.ts
@@ -23,7 +23,7 @@ export async function associatedSchemaDocument(document: vscode.TextDocument): P
         const schemaDocument = await vscode.workspace.openTextDocument(schemaPath);
         return schemaDocument;
     } catch {
-        // It throws if the schema document doesn't exist or isn't parseable - we can just abandon ship in these cases
+        // It throws if the schema document doesn't exist - we can just abandon ship in this case
         return null;
     }
 }

--- a/src/authoring/associations.ts
+++ b/src/authoring/associations.ts
@@ -18,14 +18,19 @@ export async function associatedSchema(document: vscode.TextDocument): Promise<J
 
 export async function associatedSchemaDocument(document: vscode.TextDocument): Promise<vscode.TextDocument | null> {
     try {
-        const regoPath = document.uri.fsPath;
-        const schemaPath = changeExtension(regoPath, 'schema.json');
+        const schemaPath = associatedSchemaPath(document);
         const schemaDocument = await vscode.workspace.openTextDocument(schemaPath);
         return schemaDocument;
     } catch {
         // It throws if the schema document doesn't exist - we can just abandon ship in this case
         return null;
     }
+}
+
+export function associatedSchemaPath(document: vscode.TextDocument): string {
+    const regoPath = document.uri.fsPath;
+    const schemaPath = changeExtension(regoPath, 'schema.json');
+    return schemaPath;
 }
 
 export interface JSONSchema {

--- a/src/authoring/associations.ts
+++ b/src/authoring/associations.ts
@@ -34,6 +34,7 @@ export function associatedSchemaPath(document: vscode.TextDocument): string {
 }
 
 export interface JSONSchema {
+    readonly $schema?: string;
     readonly type?: string;
     readonly properties?: { [name: string]: JSONSchema };
     readonly items?: JSONSchema;

--- a/src/commands/parametersSchema.ts
+++ b/src/commands/parametersSchema.ts
@@ -64,6 +64,8 @@ function* extractInputParameters(rego: string) {
         return;
     }
 
+    const seen = Array.of<string>();
+
     for (const reference of parameterReferences) {
         if (reference.groups.length < 2) {
             continue;
@@ -71,6 +73,12 @@ function* extractInputParameters(rego: string) {
 
         const parameterName = reference.groups[1];
         const isArray = !!(reference.groups[2]);
+
+        if (seen.includes(parameterName)) {
+            continue;
+        }
+
+        seen.push(parameterName);
 
         yield { name: parameterName, isArray };
     }

--- a/src/commands/parametersSchema.ts
+++ b/src/commands/parametersSchema.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
-import { associatedSchemaDocument } from '../authoring/associations';
+
+import { associatedSchemaDocument, associatedSchemaPath } from '../authoring/associations';
+import { fs } from '../utils/fs';
 
 export async function parametersSchema(textEditor: vscode.TextEditor, _edit: vscode.TextEditorEdit) {
     const regoDoc = textEditor.document;
@@ -10,5 +12,21 @@ export async function parametersSchema(textEditor: vscode.TextEditor, _edit: vsc
         return;
     }
 
-    vscode.window.showWarningMessage("You haven't done creating new ones yet Ivan!");
+    await openNewSchema(regoDoc);
+}
+
+async function openNewSchema(regoDoc: vscode.TextDocument): Promise<void> {
+    const schemaPath = associatedSchemaPath(regoDoc);
+    await fs.writeFile(schemaPath, schemaJSON());
+    const schemaDoc = await vscode.workspace.openTextDocument(schemaPath);
+    await vscode.window.showTextDocument(schemaDoc);
+}
+
+function schemaJSON(): string {
+    const schema = {
+        $schema: 'http://json-schema.org/draft-07/schema',
+        properties: { }
+    };
+
+    return JSON.stringify(schema, undefined, 2);
 }

--- a/src/commands/parametersSchema.ts
+++ b/src/commands/parametersSchema.ts
@@ -1,5 +1,14 @@
 import * as vscode from 'vscode';
+import { associatedSchemaDocument } from '../authoring/associations';
 
 export async function parametersSchema(textEditor: vscode.TextEditor, _edit: vscode.TextEditorEdit) {
-    await vscode.window.showInformationMessage('parameters schema');
+    const regoDoc = textEditor.document;
+    const associatedSchemaDoc = await associatedSchemaDocument(regoDoc);
+
+    if (associatedSchemaDoc) {
+        await vscode.window.showTextDocument(associatedSchemaDoc);
+        return;
+    }
+
+    vscode.window.showWarningMessage("You haven't done creating new ones yet Ivan!");
 }

--- a/src/commands/parametersSchema.ts
+++ b/src/commands/parametersSchema.ts
@@ -1,0 +1,5 @@
+import * as vscode from 'vscode';
+
+export async function parametersSchema(textEditor: vscode.TextEditor, _edit: vscode.TextEditorEdit) {
+    await vscode.window.showInformationMessage('parameters schema');
+}

--- a/src/commands/parametersSchema.ts
+++ b/src/commands/parametersSchema.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 
-import { associatedSchemaDocument, associatedSchemaPath } from '../authoring/associations';
+import { associatedSchemaDocument, associatedSchemaPath, JSONSchema } from '../authoring/associations';
 import { fs } from '../utils/fs';
+import * as regex from '../utils/regex';
 
 export async function parametersSchema(textEditor: vscode.TextEditor, _edit: vscode.TextEditorEdit) {
     const regoDoc = textEditor.document;
@@ -17,16 +18,60 @@ export async function parametersSchema(textEditor: vscode.TextEditor, _edit: vsc
 
 async function openNewSchema(regoDoc: vscode.TextDocument): Promise<void> {
     const schemaPath = associatedSchemaPath(regoDoc);
-    await fs.writeFile(schemaPath, schemaJSON());
+    await fs.writeFile(schemaPath, schemaJSON(regoDoc.getText()));
     const schemaDoc = await vscode.workspace.openTextDocument(schemaPath);
     await vscode.window.showTextDocument(schemaDoc);
 }
 
-function schemaJSON(): string {
+function schemaJSON(rego: string): string {
     const schema = {
         $schema: 'http://json-schema.org/draft-07/schema',
-        properties: { }
+        properties: schemaProperties(rego)
     };
 
     return JSON.stringify(schema, undefined, 2);
+}
+
+function schemaProperties(rego: string): { [key: string]: JSONSchema } {
+    const parameters = Array.of(...extractInputParameters(rego));
+    const properties: { [key: string]: any } = { };
+    for (const parameter of parameters) {
+        properties[parameter.name] = parameterSchema(parameter);
+    }
+    return properties;
+}
+
+function parameterSchema(parameter: { isArray: boolean }): JSONSchema {
+    if (parameter.isArray) {
+        return {
+            type: 'array',
+            items: {
+                type: 'string'
+            }
+        };
+    } else {
+        return {
+            type: 'string'
+        };
+    }
+}
+
+const PARAMETER_REF_REGEX = /input\.parameters\.([a-z][a-z0-9_]*)(\[)?/ig;
+
+function* extractInputParameters(rego: string) {
+    const parameterReferences = Array.of(...regex.exec(rego, PARAMETER_REF_REGEX));
+    if (!parameterReferences) {
+        return;
+    }
+
+    for (const reference of parameterReferences) {
+        if (reference.groups.length < 2) {
+            continue;
+        }
+
+        const parameterName = reference.groups[1];
+        const isArray = !!(reference.groups[2]);
+
+        yield { name: parameterName, isArray };
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import * as diagnostics from './diagnostics/diagnostics';
 import { GatekeeperCodeActionProvider } from './diagnostics/codeactionprovider';
 import { setEnforcementAction } from './commands/setEnforcementAction';
 import { deployTemplate } from './commands/deployTemplate';
+import { parametersSchema } from './commands/parametersSchema';
 
 export async function activate(context: vscode.ExtensionContext) {
     const clusterExplorer = await k8s.extension.clusterExplorer.v1;
@@ -36,6 +37,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('gatekeeper.enforcementAction', setEnforcementAction),
         vscode.commands.registerCommand('gatekeeper.violations', showViolations),
         vscode.commands.registerTextEditorCommand('gatekeeper.deployTemplate', deployTemplate),
+        vscode.commands.registerTextEditorCommand('gatekeeper.schema', parametersSchema),
         vscode.languages.registerCodeActionsProvider(regoSelector, codeActionProvider, { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }),
         vscode.workspace.registerFileSystemProvider(GK_REGO_RESOURCE_SCHEME, regofs),
     ];


### PR DESCRIPTION
Provides a way to jump to the `.schema.json` of a `.rego` file, creating one if necessary based on the `input.parameters.*` entries in the Rego.